### PR TITLE
IA-1342 Prevent index out of range when drawHighlighted

### DIFF
--- a/Source/Charts/Renderers/LineChartRenderer.swift
+++ b/Source/Charts/Renderers/LineChartRenderer.swift
@@ -772,6 +772,8 @@ open class LineChartRenderer: LineRadarRenderer
         
         for high in indices
         {
+            guard checkHighlightedIndexSettable(for: lineData, at: high.dataSetIndex) else { continue }
+
             guard let set = lineData[high.dataSetIndex] as? LineChartDataSetProtocol
                 , set.isHighlightEnabled
                 else { continue }
@@ -942,5 +944,13 @@ open class LineChartRenderer: LineRadarRenderer
         modifier(element)
 
         return element
+    }
+    
+    private func checkHighlightedIndexSettable(for lineData: LineChartData, at index: Int) -> Bool {
+        guard !lineData.isEmpty,
+              index >= 0 && index < lineData.count else {
+                  return false
+              }
+        return true
     }
 }


### PR DESCRIPTION
### Issue Link :link:
<!-- What issue does this fix? If an issue doesn't exist, remove this section. -->
Bugsnag [link](https://app.bugsnag.com/foris-limited/monaco-ios/errors/6246243f5492680008b1ebe1?filters%5Bapp.release_stage%5D=production&filters%5Brelease.seen_in%5D=3.136%20(22015)&filters%5Bevent.unhandled%5D=true&pivot_tab=event)

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
To make sure the index is available in lineData array
<!-- Include any relevant context. -->

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
Use `guard` to make sure we access lineData array safely
<!-- Highlight any new functionality. -->

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
Actually did not reproduce the crash by myself successfully by going through all the view controllers in monaco-ios with Charts imported, thanks to KC's big hint about where to amend in Charts according to the crash